### PR TITLE
Handle constant or single-point data in sparkline rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -813,13 +813,16 @@
 
     function drawSparkline(svgId, data, hlines=[]) {
       const svg = document.getElementById(svgId);
-      if (!svg || !data.length) return;
+      // need at least two points and a valid SVG element to draw
+      if (!svg || data.length < 2) return;
       svg.innerHTML = '';
       const w = 600, h = 150;
       const vals = data.map(p => p.v);
       const times = data.map(p => p.t.getTime());
       const minT = Math.min(...times), maxT = Math.max(...times);
       const minV = Math.min(...vals), maxV = Math.max(...vals);
+      // avoid divide-by-zero when all timestamps or values are identical
+      if (minT === maxT || minV === maxV) return;
       const pad = 0.05 * (maxV - minV);
       const yMin = minV - pad, yMax = maxV + pad;
 


### PR DESCRIPTION
## Summary
- Guard sparkline renderer against single-point or constant datasets to avoid divide-by-zero errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a53d8bcae4832886f4afbd3f8a8f31