### PR TITLE
feat: show active weather alerts

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,6 +225,11 @@
       <div id="daily" class="list loading"></div>
     </section>
 
+    <section id="alerts" class="card">
+      <h2 style="margin:6px 4px 12px">Watches & Warnings</h2>
+      <div id="alertsList" class="list"></div>
+    </section>
+
     <p class="footnote">
       Tip: Add this page to your phone’s home screen for quick access. Values refresh when you tap <strong>Refresh</strong>.
     </p>
@@ -445,6 +450,12 @@
       return `${dir} ${spd}`.trim() || '—';
     }
 
+    function severityColor(sev){
+      if (sev === 'Extreme' || sev === 'Severe') return 'var(--bad)';
+      if (sev === 'Moderate') return 'var(--warn)';
+      return 'var(--accent)';
+    }
+
     // --- Fetch NWS endpoints ---
     async function loadForecast() {
       $('lastUpdated').textContent = 'Loading…';
@@ -643,6 +654,52 @@
       addRow('Tuckertown Lake', vals.tuckertown, FULL_POND.tuckertown);
     }
 
+    function renderAlerts(alerts){
+      const cont = $('alertsList');
+      if (!cont) return;
+      cont.innerHTML = '';
+      if (!alerts.length) {
+        const div = document.createElement('div');
+        div.className = 'muted';
+        div.textContent = 'No active alerts.';
+        cont.appendChild(div);
+        return;
+      }
+      alerts.forEach(a => {
+        const div = document.createElement('div');
+        div.className = 'dayCard';
+        div.style.borderLeft = `6px solid ${severityColor(a.severity)}`;
+
+        const top = document.createElement('div');
+        top.className = 'top';
+        const left = document.createElement('div');
+        const title = document.createElement('div');
+        title.style.fontWeight = '800';
+        const link = document.createElement('a');
+        link.href = a.link;
+        link.target = '_blank';
+        link.rel = 'noreferrer noopener';
+        link.textContent = a.event || 'Alert';
+        title.appendChild(link);
+        const exp = document.createElement('div');
+        exp.className = 'muted';
+        exp.textContent = a.expires ? 'Expires ' + new Date(a.expires).toLocaleString() : '';
+        left.appendChild(title);
+        left.appendChild(exp);
+        top.appendChild(left);
+        div.appendChild(top);
+
+        const desc = document.createElement('div');
+        desc.className = 'muted';
+        desc.style.marginTop = '6px';
+        desc.style.whiteSpace = 'pre-line';
+        desc.textContent = a.description || '';
+        div.appendChild(desc);
+
+        cont.appendChild(div);
+      });
+    }
+
     async function loadLakeLevels(){
       const vals = { highrock: null, tuckertown: null };
       // Try operator site first for both
@@ -655,10 +712,32 @@
       renderLakeLevels(vals);
     }
 
+    async function loadAlerts(){
+      const cont = $('alertsList');
+      if (!cont) return;
+      cont.innerHTML = '<div class="muted">Loading…</div>';
+      try {
+        const url = `https://api.weather.gov/alerts/active?point=${LAT},${LON}`;
+        const data = await fetch(url, { headers: { 'Accept': 'application/geo+json' } }).then(r => r.json());
+        const alerts = (data?.features || []).map(f => ({
+          event: f.properties?.event,
+          description: f.properties?.description,
+          expires: f.properties?.expires || f.properties?.ends,
+          severity: f.properties?.severity,
+          link: f.properties?.['@id'] || f.id || f.properties?.id || ''
+        }));
+        renderAlerts(alerts);
+      } catch(err) {
+        console.warn('Alerts fetch failed', err);
+        cont.innerHTML = '<div class="muted">Failed to load alerts.</div>';
+      }
+    }
+
     // --- Initial Load ---
     function initialLoad() {
       loadForecast();
       loadLakeLevels();
+      loadAlerts();
       initRadarAnimation();
     }
 


### PR DESCRIPTION
## Summary
- add alerts card to display active watches and warnings
- fetch NWS alert feed and render alerts with severity coloring, sanitized description, and detail links
- include alerts in initial page refresh cycle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0965901d883289e6de35eabab027f