### PR TITLE
fix: proxy long-range forecast API

### DIFF
--- a/index.html
+++ b/index.html
@@ -527,7 +527,7 @@
       if (!cont) return;
       cont.classList.add('loading');
       try {
-        const url = `https://forecast.weather.gov/MapClick.php?lat=${LAT}&lon=${LON}&FcstType=digitalJSON`;
+        const url = `https://r.jina.ai/https://forecast.weather.gov/MapClick.php?lat=${LAT}&lon=${LON}&FcstType=digitalJSON`;
         const data = await fetch(url).then(r => r.json());
         const names = data?.time?.startPeriodName || [];
         const temps = data?.data?.temperature || [];


### PR DESCRIPTION
## Summary
- proxy long-range forecast request through r.jina.ai to bypass CORS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2dd01d6c8328b2eef44009194212