### PR TITLE
fix: validate humidity for dew point

### DIFF
--- a/index.html
+++ b/index.html
@@ -482,9 +482,10 @@
     // Dew point (Magnus formula)
     function dewPointF(tempF, rh) {
       if (tempF == null || rh == null) return null;
+      if (rh <= 0 || rh > 100) return null;
       const tC = (tempF - 32) * 5/9;
       const a = 17.27, b = 237.7;
-      const gamma = (a * tC) / (b + tC) + Math.log(Math.max(1e-6, rh) / 100);
+      const gamma = (a * tC) / (b + tC) + Math.log(Math.min(Math.max(rh, 1), 100) / 100);
       const dpC = (b * gamma) / (a - gamma);
       return Math.round(dpC * 9/5 + 32);
     }


### PR DESCRIPTION
## Summary
- avoid computing dew point with invalid humidity values by bounding humidity to a sane range

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3ac489ac8328b001055d38d78552